### PR TITLE
Update design for Discord Presence

### DIFF
--- a/src/main/java/fr/arsenelapostolet/plexrichpresence/viewmodel/MainViewModel.java
+++ b/src/main/java/fr/arsenelapostolet/plexrichpresence/viewmodel/MainViewModel.java
@@ -195,15 +195,15 @@ public class MainViewModel {
         final String currentPlayerState;
         switch (session.getPlayer().getState()) {
             case "buffering":
-                currentPlayerState = "Buffering";
+                currentPlayerState = "⟲";
                 richPresence.setEndTimestamp(currentTime);
                 break;
             case "paused":
-                currentPlayerState = "Paused";
+                currentPlayerState = "⏸";
                 richPresence.setEndTimestamp(currentTime);
                 break;
             default:
-                currentPlayerState = "Playing";
+                currentPlayerState = "⏵";
                 richPresence.setEndTimestamp(currentTime + ((Long.parseLong(session.getDuration()) - Long.parseLong(session.getViewOffset())) / 1000));
                 break;
         }
@@ -213,7 +213,7 @@ public class MainViewModel {
                 richPresence.updateMessage(currentPlayerState, session.getTitle());
                 break;
             case "episode":
-                richPresence.updateMessage(String.format("(%s) %s", currentPlayerState, session.getGrandparentTitle()), String.format("S%02dE%02d - %s", Integer.parseInt(session.getParentIndex()), Integer.parseInt(session.getIndex()), session.getTitle()) );
+                richPresence.updateMessage(String.format("%s %s", currentPlayerState, session.getGrandparentTitle()), String.format("⏏ %02dx%02d - %s", Integer.parseInt(session.getParentIndex()), Integer.parseInt(session.getIndex()), session.getTitle()) );
                 break;
             default:
                 richPresence.updateMessage(

--- a/src/main/java/fr/arsenelapostolet/plexrichpresence/viewmodel/MainViewModel.java
+++ b/src/main/java/fr/arsenelapostolet/plexrichpresence/viewmodel/MainViewModel.java
@@ -203,7 +203,7 @@ public class MainViewModel {
                 richPresence.setEndTimestamp(currentTime);
                 break;
             default:
-                currentPlayerState = "⏵";
+                currentPlayerState = "▶";
                 richPresence.setEndTimestamp(currentTime + ((Long.parseLong(session.getDuration()) - Long.parseLong(session.getViewOffset())) / 1000));
                 break;
         }


### PR DESCRIPTION
Improved the design of the Rich Embed by quite a bit, icon used for episode info is debatable but undoubedly looks better with icon on both rows. Using SxE also greatly improves readability over S00E00

**Playing:**
![image](https://user-images.githubusercontent.com/10836780/106412886-05585f80-6449-11eb-84f3-9a35fa9227fa.png?s=200)
![image](https://user-images.githubusercontent.com/10836780/106414006-d7284f00-644b-11eb-97cd-6f55ff4ce64d.png?s=200)

**Paused:**
![image](https://user-images.githubusercontent.com/10836780/106413010-4ea8af00-6449-11eb-9273-76b283e14c4c.png)
![image](https://user-images.githubusercontent.com/10836780/106414184-4aca5c00-644c-11eb-9c79-3e937fb8851b.png)
(Couldn't find a Pause unicode symbol that looked like the desktop variant, but on mobile)

**Buffer:**
Can't artificially buffer my stream so can't display here