### PR TITLE
docs(readme): fix logo and download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Plex Rich Presence works with Java 8.
 
 ## Release Version
 
-- [Portable and Executable JAR](https://github.com/Ombrelin/plex-rich-presence/releases/download/v1.3/plex-rich-presence-1.4.jar)
-- [Windows Installer](https://github.com/Ombrelin/plex-rich-presence/releases/download/v1.3/plex-rich-presence-setup.exe)
+- [Portable and Executable JAR](https://github.com/Ombrelin/plex-rich-presence/releases/latest/download/plex-rich-presence-1.4.jar)
+- [Windows Installer](https://github.com/Ombrelin/plex-rich-presence/releases/latest/download/plex-rich-presence-setup.exe)
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Plex Rich Presence is a multiplatform Java GUI App that allows you to display your current PLEX session in your Discord Rich presence status.
 Plex Rich Presence works with Java 8.
 
-<img src="https://github.com/Ombrelin/plex-rich-presence/blob/master/src/main/resources/images/icon.png?raw=true" width="250" height="250">
+<img src="src/main/resources/images/icon.png?raw=true" width="250" height="250">
 
 ## Release Version
 


### PR DESCRIPTION
The download links weren't linking to the proper tag, so I changed them to target latest tag instead.

Then I figured I might as well make a relative link for the logo as well.