### PR TITLE
Fixed Remaining Time Timezone Issue

### DIFF
--- a/src/PlexRichPresence.DiscordRichPresence/Rendering/GenericSessionRenderer.cs
+++ b/src/PlexRichPresence.DiscordRichPresence/Rendering/GenericSessionRenderer.cs
@@ -31,9 +31,9 @@ public class GenericSessionRenderer : IPlexSessionRenderer
     {
         return session.PlayerState switch
         {
-            PlexPlayerState.Buffering => ("⟲", this.clock.Now),
-            PlexPlayerState.Paused => ("⏸", this.clock.Now),
-            PlexPlayerState.Playing => ("▶", this.clock.Now.AddSeconds(ComputeSessionRemainingTime(session))),
+            PlexPlayerState.Buffering => ("⟲", this.clock.Now.ToUniversalTime()),
+            PlexPlayerState.Paused => ("⏸", this.clock.Now.ToUniversalTime()),
+            PlexPlayerState.Playing => ("▶", this.clock.Now.AddSeconds(ComputeSessionRemainingTime(session)).ToUniversalTime()),
             _ => throw new ArgumentOutOfRangeException()
         };
     }


### PR DESCRIPTION
Timestamp used for displaying the remaining time was using Local Time instead of Universal Time. This caused Users with negative offsets to constantly have a remaining time of 0:00 and Users with a positive offset having a remaining time of several hours.

#77 